### PR TITLE
Drop dependency on future

### DIFF
--- a/onionbalance/common/intro_point_set.py
+++ b/onionbalance/common/intro_point_set.py
@@ -1,4 +1,3 @@
-from future.moves.itertools import zip_longest
 import random
 import itertools
 
@@ -53,7 +52,7 @@ class IntroductionPointSet(object):
         """
 
         # Combine intro points from across the backend instances and flatten
-        intro_points = zip_longest(*self.intro_points)
+        intro_points = itertools.zip_longest(*self.intro_points)
         flat_intro_points = itertools.chain.from_iterable(intro_points)
         for intro_point in itertools.cycle(flat_intro_points):
             if intro_point:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,3 @@ stem>=1.8
 pyyaml>=4.2b1
 cryptography>=3.2
 pycryptodomex
-
-future>=0.14.3

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
         'stem>=1.8',
         'PyYAML>=4.2b1',
         'pycryptodomex',
-        'future>=0.14.0',
         'setproctitle',
         'cryptography>=2.5',
     ],


### PR DESCRIPTION
I'm proposing this because future is broken with the latest Python 3.12 and will be even more with 3.13 so it might be a good idea to get rid of it.